### PR TITLE
fix(docker): run database migrations before starting gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,14 @@ COPY --from=builder /install /usr/local
 COPY --chown=app:app . .
 
 
+RUN chmod +x entrypoint.sh
+
+
 USER app
 
 
 EXPOSE 8000
 
 
-CMD ["gunicorn", "ticket_service.wsgi:application", "--bind", "0.0.0.0:8000"]
+ENTRYPOINT ["./entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+echo "Running database migrations..."
+python manage.py migrate --noinput
+
+echo "Starting Gunicorn server..."
+exec gunicorn ticket_service.wsgi:application --bind 0.0.0.0:8000


### PR DESCRIPTION
The container was crashing because the database tables were not created. Added entrypoint.sh to execute 'python manage.py migrate --noinput' before starting Gunicorn.

Also updated Dockerfile to copy the script and make it executable.